### PR TITLE
Beta3 release

### DIFF
--- a/Examples/lu-Bundle-Nierfunctie-01.xml
+++ b/Examples/lu-Bundle-Nierfunctie-01.xml
@@ -1,0 +1,310 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bundle xmlns="http://hl7.org/fhir">
+   <id value="lu-Bundle-Nierfunctie-01"/>
+   <type value="transaction"/>
+   <entry>
+      <fullUrl value="urn:uuid:dc6f125a-262c-11ee-2563-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4298.2"/>
+               <value value="11111"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen"/>
+                  <code value="3583"/>
+                  <display value="eGFR volgens CKD-EPI formule"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc6f1200-262c-11ee-2563-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <effectiveDateTime value="${DATE, T, D, -20}"/>
+            <performer>
+               <reference value="urn:uuid:dc6f121e-262c-11ee-2563-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <valueQuantity>
+               <value value="97"/>
+               <unit value="mL/min/{1.73_m2}"/>
+               <system value="http://unitsofmeasure.org"/>
+               <code value="mL/min/{1.73_m2}"/>
+            </valueQuantity>
+            <interpretation>
+               <text value="Iets bovengemiddeld"/>
+            </interpretation>
+            <specimen>
+               <reference value="urn:uuid:dc6f12b4-262c-11ee-2563-020000000000"/>
+               <type value="Specimen"/>
+               <display value="monster"/>
+            </specimen>
+            <referenceRange>
+               <low>
+                  <value value="90"/>
+                  <unit value="mL/min/{1.73_m2}"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="mL/min/{1.73_m2}"/>
+               </low>
+            </referenceRange>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6f1278-262c-11ee-2563-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4298.2"/>
+               <value value="22222"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="https://referentiemodel.nhg.org/tabellen/nhg-tabel-45-diagnostische-bepalingen"/>
+                  <code value="523"/>
+                  <display value="creatinine"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc6f1200-262c-11ee-2563-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <effectiveDateTime value="${DATE, T, D, -20}"/>
+            <performer>
+               <reference value="urn:uuid:dc6f121e-262c-11ee-2563-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <valueQuantity>
+               <value value="135"/>
+               <unit value="umol/l"/>
+               <system value="http://unitsofmeasure.org"/>
+               <code value="umol/l"/>
+            </valueQuantity>
+            <interpretation>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="281302008"/>
+                  <display value="boven referentiebereik"/>
+               </coding>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"/>
+                  <code value="H"/>
+                  <display value="High"/>
+               </coding>
+            </interpretation>
+            <interpretation>
+               <text value="Creatinine iets hoger dan normaal."/>
+            </interpretation>
+            <method>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="258026004"/>
+                  <display value="enzyme method"/>
+               </coding>
+            </method>
+            <specimen>
+               <reference value="urn:uuid:dc6f12b4-262c-11ee-2563-020000000000"/>
+               <type value="Specimen"/>
+               <display value="monster"/>
+            </specimen>
+            <referenceRange>
+               <low>
+                  <value value="60"/>
+                  <unit value="umol/l"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="umol/l"/>
+               </low>
+               <high>
+                  <value value="110"/>
+                  <unit value="umol/l"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="umol/l"/>
+               </high>
+            </referenceRange>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6f12b4-262c-11ee-2563-020000000000"/>
+      <resource>
+         <Specimen>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult.Specimen"/>
+            </meta>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4267.2"/>
+               <value value="1111"/>
+            </identifier>
+            <type>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="119297000"/>
+                  <display value="Bloed"/>
+               </coding>
+            </type>
+            <subject>
+               <reference value="urn:uuid:dc6f1200-262c-11ee-2563-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <collection>
+               <collectedDateTime value="${DATE, T, D, -20}"/>
+            </collection>
+            <note>
+               <text value="Serum afgenomen bij patiënt."/>
+            </note>
+         </Specimen>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Specimen"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6f121e-262c-11ee-2563-020000000000"/>
+      <resource>
+         <Organization>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"/>
+            </meta>
+            <identifier>
+               <system value="http://fhir.nl/fhir/NamingSystem/ura"/>
+               <value value="00003333"/>
+            </identifier>
+            <type>
+               <coding>
+                  <system value="http://nictiz.nl/fhir/NamingSystem/organization-type"/>
+                  <version value="2022-09-10T00:00:00"/>
+                  <code value="L1"/>
+                  <display value="Laboratorium"/>
+               </coding>
+            </type>
+            <name value="Klinisch chemisch Lab 't Proefje"/>
+            <telecom>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-Comment">
+                  <valueString value="Bel met vragen"/>
+               </extension>
+               <system value="phone"/>
+               <value value="06-11122233"/>
+               <use value="work"/>
+            </telecom>
+            <telecom>
+               <system value="email"/>
+               <value value="tproefje@lab.nl"/>
+               <use value="work"/>
+            </telecom>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-AddressInformation.AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Hoofdstraat 23">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Hoofdstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="23"/>
+                  </extension>
+               </line>
+               <city value="Zorgstad"/>
+               <postalCode value="1234AA"/>
+            </address>
+         </Organization>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Organization"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6f1200-262c-11ee-2563-020000000000"/>
+      <resource>
+         <Patient>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+            </meta>
+            <identifier>
+               <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
+               <value value="999900511"/>
+            </identifier>
+            <name>
+               <use value="official"/>
+               <text value="E. XXX_Doppen"/>
+               <family value="XXX_Doppen">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+                     <valueString value="XXX_Doppen"/>
+                  </extension>
+               </family>
+               <given value="E.">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+                     <valueCode value="IN"/>
+                  </extension>
+               </given>
+            </name>
+            <gender value="male">
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CodeSpecification">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender"/>
+                        <code value="M"/>
+                        <display value="Man"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+            </gender>
+            <birthDate value="1963-10-24"/>
+         </Patient>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Patient"/>
+      </request>
+   </entry>
+</Bundle>

--- a/Examples/lu-Bundle-Nierfunctie-02.xml
+++ b/Examples/lu-Bundle-Nierfunctie-02.xml
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bundle xmlns="http://hl7.org/fhir">
+   <id value="lu-Bundle-Nierfunctie-02"/>
+   <type value="transaction"/>
+   <entry>
+      <fullUrl value="urn:uuid:dc66a66a-262c-11ee-3385-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CopyIndicator">
+               <valueBoolean value="true"/>
+            </extension>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4296.2"/>
+               <value value="LAR_NierfunctiePanelLOINC"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="http://loinc.org"/>
+                  <code value="45066-8"/>
+                  <display value="creatinine &amp; glomerulaire filtratiesnelheid.voorspeld panel"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc66a5d4-262c-11ee-3385-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <performer>
+               <reference value="urn:uuid:dc66a5f2-262c-11ee-3385-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <specimen>
+               <reference value="urn:uuid:dc66a688-262c-11ee-3385-020000000000"/>
+               <type value="Specimen"/>
+               <display value="monster"/>
+            </specimen>
+            <hasMember>
+               <reference value="urn:uuid:dc66a62e-262c-11ee-3385-020000000000"/>
+               <type value="Observation"/>
+               <display value="laboratorium_test"/>
+            </hasMember>
+            <hasMember>
+               <reference value="urn:uuid:dc66a64c-262c-11ee-3385-020000000000"/>
+               <type value="Observation"/>
+               <display value="laboratorium_test"/>
+            </hasMember>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc66a62e-262c-11ee-3385-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CopyIndicator">
+               <valueBoolean value="true"/>
+            </extension>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4298.2"/>
+               <value value="11111"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="http://loinc.org"/>
+                  <code value="98979-8"/>
+                  <display value="Glomerulaire filtratiesnelheid/1,73 m2.voorspeld [filtratiesnelheid/oppervlakte] in serum of plasma of bloed d.m.v. formule gebaseerd op creatinine (CKD-EPI 2021)"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc66a5d4-262c-11ee-3385-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <effectiveDateTime value="${DATE, T, D, -20}"/>
+            <performer>
+               <reference value="urn:uuid:dc66a5f2-262c-11ee-3385-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <valueQuantity>
+               <value value="97"/>
+               <unit value="mL/min/{1.73_m2}"/>
+               <system value="http://unitsofmeasure.org"/>
+               <code value="mL/min/{1.73_m2}"/>
+            </valueQuantity>
+            <interpretation>
+               <text value="Waarde is goed."/>
+            </interpretation>
+            <specimen>
+               <reference value="urn:uuid:dc66a688-262c-11ee-3385-020000000000"/>
+               <type value="Specimen"/>
+               <display value="monster"/>
+            </specimen>
+            <referenceRange>
+               <low>
+                  <value value="90"/>
+                  <unit value="mL/min/{1.73_m2}"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="mL/min/{1.73_m2}"/>
+               </low>
+            </referenceRange>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc66a64c-262c-11ee-3385-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CopyIndicator">
+               <valueBoolean value="true"/>
+            </extension>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4298.2"/>
+               <value value="22222"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="http://loinc.org"/>
+                  <code value="45066-8"/>
+                  <display value="Creatinine [mol/volume] in urine"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc66a5d4-262c-11ee-3385-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <effectiveDateTime value="${DATE, T, D, -20}"/>
+            <performer>
+               <reference value="urn:uuid:dc66a5f2-262c-11ee-3385-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <valueQuantity>
+               <value value="135"/>
+               <unit value="umol/l"/>
+               <system value="http://unitsofmeasure.org"/>
+               <code value="umol/l"/>
+            </valueQuantity>
+            <interpretation>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="281302008"/>
+                  <display value="boven referentiebereik"/>
+               </coding>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"/>
+                  <code value="H"/>
+                  <display value="High"/>
+               </coding>
+            </interpretation>
+            <interpretation>
+               <text value="Creatinine iets hoger dan normaal."/>
+            </interpretation>
+            <method>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="258026004"/>
+                  <display value="enzyme method"/>
+               </coding>
+            </method>
+            <specimen>
+               <reference value="urn:uuid:dc66a688-262c-11ee-3385-020000000000"/>
+               <type value="Specimen"/>
+               <display value="monster"/>
+            </specimen>
+            <referenceRange>
+               <low>
+                  <value value="62"/>
+                  <unit value="umol/l"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="umol/l"/>
+               </low>
+               <high>
+                  <value value="134"/>
+                  <unit value="umol/l"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="umol/l"/>
+               </high>
+            </referenceRange>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc66a688-262c-11ee-3385-020000000000"/>
+      <resource>
+         <Specimen>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult.Specimen"/>
+            </meta>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4267.2"/>
+               <value value="123"/>
+            </identifier>
+            <type>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="119297000"/>
+                  <display value="Bloed"/>
+               </coding>
+            </type>
+            <subject>
+               <reference value="urn:uuid:dc66a5d4-262c-11ee-3385-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <collection>
+               <collectedDateTime value="${DATE, T, D, -20}"/>
+            </collection>
+            <note>
+               <text value="Serum afgenomen bij patiënt."/>
+            </note>
+         </Specimen>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Specimen"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc66a5f2-262c-11ee-3385-020000000000"/>
+      <resource>
+         <Organization>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"/>
+            </meta>
+            <identifier>
+               <system value="http://fhir.nl/fhir/NamingSystem/ura"/>
+               <value value="00003333"/>
+            </identifier>
+            <type>
+               <coding>
+                  <system value="http://nictiz.nl/fhir/NamingSystem/organization-type"/>
+                  <version value="2022-09-10T00:00:00"/>
+                  <code value="L1"/>
+                  <display value="Laboratorium"/>
+               </coding>
+            </type>
+            <name value="Klinisch chemisch Lab 't Proefje"/>
+            <telecom>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-Comment">
+                  <valueString value="Bel met vragen"/>
+               </extension>
+               <system value="phone"/>
+               <value value="06-11122233"/>
+               <use value="work"/>
+            </telecom>
+            <telecom>
+               <system value="email"/>
+               <value value="tproefje@lab.nl"/>
+               <use value="work"/>
+            </telecom>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-AddressInformation.AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Hoofdstraat 23">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Hoofdstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="23"/>
+                  </extension>
+               </line>
+               <city value="Zorgstad"/>
+               <postalCode value="1234AA"/>
+            </address>
+         </Organization>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Organization"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc66a5d4-262c-11ee-3385-020000000000"/>
+      <resource>
+         <Patient>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+            </meta>
+            <identifier>
+               <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
+               <value value="999900511"/>
+            </identifier>
+            <name>
+               <use value="official"/>
+               <text value="E. XXX_Doppen"/>
+               <family value="XXX_Doppen">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+                     <valueString value="XXX_Doppen"/>
+                  </extension>
+               </family>
+               <given value="E.">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+                     <valueCode value="IN"/>
+                  </extension>
+               </given>
+            </name>
+            <gender value="male">
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CodeSpecification">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender"/>
+                        <code value="M"/>
+                        <display value="Man"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+            </gender>
+            <birthDate value="1963-10-24"/>
+         </Patient>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Patient"/>
+      </request>
+   </entry>
+</Bundle>

--- a/Examples/lu-Bundle-Nierfunctie-03.xml
+++ b/Examples/lu-Bundle-Nierfunctie-03.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bundle xmlns="http://hl7.org/fhir">
+   <id value="lu-Bundle-Nierfunctie-03"/>
+   <type value="transaction"/>
+   <entry>
+      <fullUrl value="urn:uuid:dc6a940a-262c-11ee-2103-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CopyIndicator">
+               <valueBoolean value="true"/>
+            </extension>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4298.2"/>
+               <value value="11111"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="http://loinc.org"/>
+                  <code value="98979-8"/>
+                  <display value="Glomerulaire filtratiesnelheid/1,73 m2.voorspeld [filtratiesnelheid/oppervlakte] in serum of plasma of bloed d.m.v. formule gebaseerd op creatinine (CKD-EPI 2021)"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc6a93b0-262c-11ee-2103-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <effectiveDateTime value="${DATE, T, D, -20}"/>
+            <performer>
+               <reference value="urn:uuid:dc6a93ce-262c-11ee-2103-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <valueQuantity>
+               <value value="97"/>
+               <unit value="mL/min/{1.73_m2}"/>
+               <system value="http://unitsofmeasure.org"/>
+               <code value="mL/min/{1.73_m2}"/>
+            </valueQuantity>
+            <interpretation>
+               <text value="Waarde is goed."/>
+            </interpretation>
+            <referenceRange>
+               <low>
+                  <value value="90"/>
+                  <unit value="mL/min/{1.73_m2}"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="mL/min/{1.73_m2}"/>
+               </low>
+            </referenceRange>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6a9428-262c-11ee-2103-020000000000"/>
+      <resource>
+         <Observation>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult"/>
+            </meta>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CopyIndicator">
+               <valueBoolean value="true"/>
+            </extension>
+            <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-EdifactReferenceNumber">
+               <valueString value="111222"/>
+            </extension>
+            <identifier>
+               <system value="urn:oid:2.16.840.1.113883.2.4.3.11.999.25.4298.2"/>
+               <value value="22222"/>
+            </identifier>
+            <status value="final"/>
+            <category>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/observation-category"/>
+                  <code value="laboratory"/>
+                  <display value="Laboratory"/>
+               </coding>
+            </category>
+            <code>
+               <coding>
+                  <system value="http://loinc.org"/>
+                  <code value="45066-8"/>
+                  <display value="Creatinine [mol/volume] in urine"/>
+               </coding>
+            </code>
+            <subject>
+               <reference value="urn:uuid:dc6a93b0-262c-11ee-2103-020000000000"/>
+               <type value="Patient"/>
+               <display value="Patient, E. XXX_Doppen"/>
+            </subject>
+            <effectiveDateTime value="2022-03-01T09:10:00+01:00"/>
+            <performer>
+               <reference value="urn:uuid:dc6a93ce-262c-11ee-2103-020000000000"/>
+               <type value="Organization"/>
+               <display value="Healthcare provider (organization), Klinisch chemisch Lab 't Proefje"/>
+            </performer>
+            <valueQuantity>
+               <value value="135"/>
+               <unit value="umol/l"/>
+               <system value="http://unitsofmeasure.org"/>
+               <code value="umol/l"/>
+            </valueQuantity>
+            <interpretation>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="281302008"/>
+                  <display value="boven referentiebereik"/>
+               </coding>
+               <coding>
+                  <system value="http://terminology.hl7.org/CodeSystem/v3-ObservationInterpretation"/>
+                  <code value="H"/>
+                  <display value="High"/>
+               </coding>
+            </interpretation>
+            <interpretation>
+               <text value="Creatinine iets hoger dan normaal."/>
+            </interpretation>
+            <method>
+               <coding>
+                  <system value="http://snomed.info/sct"/>
+                  <code value="258026004"/>
+                  <display value="enzyme method"/>
+               </coding>
+            </method>
+            <referenceRange>
+               <low>
+                  <value value="62"/>
+                  <unit value="umol/l"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="umol/l"/>
+               </low>
+               <high>
+                  <value value="134"/>
+                  <unit value="umol/l"/>
+                  <system value="http://unitsofmeasure.org"/>
+                  <code value="umol/l"/>
+               </high>
+            </referenceRange>
+         </Observation>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Observation"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6a93ce-262c-11ee-2103-020000000000"/>
+      <resource>
+         <Organization>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization"/>
+            </meta>
+            <identifier>
+               <system value="http://fhir.nl/fhir/NamingSystem/ura"/>
+               <value value="00003333"/>
+            </identifier>
+            <type>
+               <coding>
+                  <system value="http://nictiz.nl/fhir/NamingSystem/organization-type"/>
+                  <version value="2022-09-10T00:00:00"/>
+                  <code value="L1"/>
+                  <display value="Laboratorium"/>
+               </coding>
+            </type>
+            <name value="Klinisch chemisch Lab 't Proefje"/>
+            <telecom>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-Comment">
+                  <valueString value="Bel met vragen"/>
+               </extension>
+               <system value="phone"/>
+               <value value="06-11122233"/>
+               <use value="work"/>
+            </telecom>
+            <telecom>
+               <system value="email"/>
+               <value value="tproefje@lab.nl"/>
+               <use value="work"/>
+            </telecom>
+            <address>
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-AddressInformation.AddressType">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v3-AddressUse"/>
+                        <code value="WP"/>
+                        <display value="Werkadres"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+               <use value="work"/>
+               <line value="Hoofdstraat 23">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-streetName">
+                     <valueString value="Hoofdstraat"/>
+                  </extension>
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-ADXP-houseNumber">
+                     <valueString value="23"/>
+                  </extension>
+               </line>
+               <city value="Zorgstad"/>
+               <postalCode value="1234AA"/>
+            </address>
+         </Organization>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Organization"/>
+      </request>
+   </entry>
+   <entry>
+      <fullUrl value="urn:uuid:dc6a93b0-262c-11ee-2103-020000000000"/>
+      <resource>
+         <Patient>
+            <meta>
+               <profile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient"/>
+            </meta>
+            <identifier>
+               <system value="http://fhir.nl/fhir/NamingSystem/bsn"/>
+               <value value="999900511"/>
+            </identifier>
+            <name>
+               <use value="official"/>
+               <text value="E. XXX_Doppen"/>
+               <family value="XXX_Doppen">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/humanname-own-name">
+                     <valueString value="XXX_Doppen"/>
+                  </extension>
+               </family>
+               <given value="E.">
+                  <extension url="http://hl7.org/fhir/StructureDefinition/iso21090-EN-qualifier">
+                     <valueCode value="IN"/>
+                  </extension>
+               </given>
+            </name>
+            <gender value="male">
+               <extension url="http://nictiz.nl/fhir/StructureDefinition/ext-CodeSpecification">
+                  <valueCodeableConcept>
+                     <coding>
+                        <system value="http://terminology.hl7.org/CodeSystem/v3-AdministrativeGender"/>
+                        <code value="M"/>
+                        <display value="Man"/>
+                     </coding>
+                  </valueCodeableConcept>
+               </extension>
+            </gender>
+            <birthDate value="1963-10-24"/>
+         </Patient>
+      </resource>
+      <request>
+         <method value="POST"/>
+         <url value="Patient"/>
+      </request>
+   </entry>
+</Bundle>

--- a/Resources/lu-Composition.xml
+++ b/Resources/lu-Composition.xml
@@ -37,7 +37,7 @@
     <element id="Composition.identifier">
       <path value="Composition.identifier" />
       <short value="Version-independent business identifier of the Laboratory Report (setID)" />
-      <definition value="A version-independent  Business identifier of the Laboratory Report (setID). This identifier stays constant as the Laboratory Raport may be updated and changed over time." />
+      <definition value="A version-independent  Business identifier of the Laboratory Report (setID). This identifier stays constant as the Laboratory Report may be updated and changed over time." />
       <min value="1" />
     </element>
     <element id="Composition.type">

--- a/Resources/lu-Composition.xml
+++ b/Resources/lu-Composition.xml
@@ -81,6 +81,7 @@
       <mapping>
         <identity value="lu-dataset-laboratory-exchange-2021-02-22" />
         <map value="lu-concept-v2-4294" />
+        <comment value="Uitvoerder" />
       </mapping>
     </element>
     <element id="Composition.section">

--- a/Resources/lu-Composition.xml
+++ b/Resources/lu-Composition.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="lu-Composition" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/lu-Composition" />
-  <version value="3.0.0-beta.2" />
+  <version value="3.0.0-beta.3" />
   <name value="LuComposition" />
   <title value="lu Composition" />
   <status value="draft" />
@@ -26,7 +26,7 @@
   <kind value="resource" />
   <abstract value="false" />
   <type value="Composition" />
-  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/Composition" />
+  <baseDefinition value="http://hl7.org/fhir/StructureDefinition/clinicaldocument" />
   <derivation value="constraint" />
   <differential>
     <element id="Composition">
@@ -34,25 +34,28 @@
       <short value="Laboratory Report composition" />
       <definition value="A composition is a set of healthcare-related information that is assembled together into a single logical document that provides a single coherent statement of meaning, establishes its own context and that has clinical attestation with regard to who is making the statement. While a Composition defines the structure, it does not actually contain the content: rather the full content of a document is contained in a Bundle, of which the Composition is the first resource contained." />
     </element>
+    <element id="Composition.identifier">
+      <path value="Composition.identifier" />
+      <short value="Version-independent business identifier of the Laboratory Report (setID)" />
+      <definition value="A version-independent  Business identifier of the Laboratory Report (setID). This identifier stays constant as the Laboratory Raport may be updated and changed over time." />
+      <min value="1" />
+    </element>
     <element id="Composition.type">
       <path value="Composition.type" />
       <short value="Kind of composition (Laboratory Report)" />
       <definition value="Laboratory Report" />
-    </element>
-    <element id="Composition.type.coding">
-      <path value="Composition.type.coding" />
-      <fixedCoding>
-        <system value="http://loinc.org" />
-        <code value="11502-2" />
-        <display value="Laboratory Report" />
-      </fixedCoding>
+      <patternCodeableConcept>
+        <coding>
+          <system value="http://loinc.org" />
+          <code value="11502-2" />
+        </coding>
+      </patternCodeableConcept>
     </element>
     <element id="Composition.subject">
       <path value="Composition.subject" />
       <min value="1" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Resource" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />
       </type>
       <mapping>
@@ -61,10 +64,24 @@
         <comment value="Patient" />
       </mapping>
     </element>
-    <element id="Composition.section">
-      <path value="Composition.section" />
-      <min value="1" />
-      <max value="1" />
+    <element id="Composition.author">
+      <path value="Composition.author" />
+      <short value="Who and/or what authored the Laboratory Report" />
+      <definition value="The organization authored the Laboratory Report. This is the same organization that is responsible for the completion of the LaboratoryTestResult." />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Practitioner" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/PractitionerRole" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Device" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Patient" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/RelatedPerson" />
+        <targetProfile value="http://hl7.org/fhir/StructureDefinition/Organization" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-HealthcareProvider-Organization" />
+      </type>
+      <mapping>
+        <identity value="lu-dataset-laboratory-exchange-2021-02-22" />
+        <map value="lu-concept-v2-4294" />
+      </mapping>
     </element>
     <element id="Composition.section.code">
       <path value="Composition.section.code" />

--- a/Resources/lu-Composition.xml
+++ b/Resources/lu-Composition.xml
@@ -83,7 +83,22 @@
         <map value="lu-concept-v2-4294" />
       </mapping>
     </element>
-    <element id="Composition.section.code">
+    <element id="Composition.section">
+      <path value="Composition.section" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="code" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="1" />
+    </element>
+    <element id="Composition.section:panel">
+      <path value="Composition.section" />
+      <sliceName value="panel" />
+    </element>
+    <element id="Composition.section:panel.code">
       <path value="Composition.section.code" />
       <binding>
         <strength value="preferred" />
@@ -96,14 +111,50 @@
         <comment value="PanelOrBattery" />
       </mapping>
     </element>
-    <element id="Composition.section.entry">
+    <element id="Composition.section:panel.entry">
       <path value="Composition.section.entry" />
+      <max value="0" />
+    </element>
+    <element id="Composition.section:panel.section">
+      <path value="Composition.section.section" />
       <min value="1" />
-      <max value="1" />
+    </element>
+    <element id="Composition.section:panel.section.entry">
+      <path value="Composition.section.section.entry" />
+      <min value="1" />
       <type>
         <code value="Reference" />
-        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/lu-LaboratoryTestResult-DiagnosticReport" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult" />
       </type>
+    </element>
+    <element id="Composition.section:battery">
+      <path value="Composition.section" />
+      <sliceName value="battery" />
+    </element>
+    <element id="Composition.section:battery.code">
+      <path value="Composition.section.code" />
+      <binding>
+        <strength value="preferred" />
+        <description value="PanelOrBatteryCodelist" />
+        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.5--20200901000000" />
+      </binding>
+      <mapping>
+        <identity value="lu-dataset-laboratory-exchange-2021-02-22" />
+        <map value="lu-concept-v2-4286" />
+        <comment value="PanelOrBattery" />
+      </mapping>
+    </element>
+    <element id="Composition.section:battery.entry">
+      <path value="Composition.section.entry" />
+      <min value="1" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-LaboratoryTestResult" />
+      </type>
+    </element>
+    <element id="Composition.section:battery.section">
+      <path value="Composition.section.section" />
+      <max value="0" />
     </element>
   </differential>
 </StructureDefinition>

--- a/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
+++ b/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="lu-LaboratoryTestResult-DiagnosticReport" />
   <url value="http://nictiz.nl/fhir/StructureDefinition/lu-LaboratoryTestResult-DiagnosticReport" />
-  <version value="3.0.0-beta.2" />
+  <version value="3.0.0-beta.3" />
   <name value="LuLaboratoryTestResultDiagnosticReport" />
   <title value="lu LaboratoryTestResult DiagnosticReport" />
   <status value="draft" />

--- a/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
+++ b/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
@@ -46,6 +46,29 @@
         <comment value="LaboratoryTestResult" />
       </mapping>
     </element>
+    <element id="DiagnosticReport.extension">
+      <path value="DiagnosticReport.extension" />
+      <slicing>
+        <discriminator>
+          <type value="value" />
+          <path value="url" />
+        </discriminator>
+        <rules value="open" />
+      </slicing>
+      <min value="0" />
+    </element>
+    <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5">
+      <path value="DiagnosticReport.extension" />
+      <sliceName value="DiagnosticReportCompositionR5" />
+      <short value="Reference to Composition in R5" />
+      <definition value="Extensions for converting between R4 and R5 to refer to Composition" />
+      <min value="0" />
+      <max value="1" />
+      <type>
+        <code value="Extension" />
+        <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
+      </type>
+    </element>
     <element id="DiagnosticReport.identifier">
       <path value="DiagnosticReport.identifier" />
       <short value="OrderId" />
@@ -90,43 +113,7 @@
     </element>
     <element id="DiagnosticReport.category">
       <path value="DiagnosticReport.category" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="$this" />
-        </discriminator>
-        <rules value="open" />
-      </slicing>
-      <comment value="In addition to the required category valueset, this element allows various categorization schemes based on the owner’s definition of the category and effectively multiple categories can be used at once. The level of granularity is defined by the category concepts in the value set." />
       <min value="1" />
-      <mustSupport value="true" />
-    </element>
-    <element id="DiagnosticReport.category:laboratoryCategory">
-      <path value="DiagnosticReport.category" />
-      <sliceName value="laboratoryCategory" />
-      <short value="Classification of type of observation" />
-      <definition value="A code that classifies the general type of observation being made." />
-      <min value="1" />
-      <max value="1" />
-      <binding>
-        <strength value="required" />
-      </binding>
-    </element>
-    <element id="DiagnosticReport.category:resultType">
-      <path value="DiagnosticReport.category" />
-      <sliceName value="resultType" />
-      <short value="ResultType" />
-      <definition value="The type of result defines the laboratory specialty under which the test is categorized." />
-      <alias value="ResultaatType" />
-      <binding>
-        <strength value="required" />
-        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.13.1.1--20200901000000" />
-      </binding>
-      <mapping>
-        <identity value="lu-dataset-laboratory-exchange-2021-02-22" />
-        <map value="lu-concept-v2-4289" />
-        <comment value="ResultType" />
-      </mapping>
     </element>
     <element id="DiagnosticReport.code">
       <path value="DiagnosticReport.code" />
@@ -148,6 +135,7 @@
     <element id="DiagnosticReport.subject">
       <path value="DiagnosticReport.subject" />
       <short value="Patient" />
+      <min value="1" />
       <type>
         <code value="Reference" />
         <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/nl-core-Patient" />

--- a/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
+++ b/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
@@ -57,9 +57,9 @@
       </slicing>
       <min value="1" />
     </element>
-    <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5">
+    <element id="DiagnosticReport.extension:diagnosticReportCompositionR5">
       <path value="DiagnosticReport.extension" />
-      <sliceName value="DiagnosticReportCompositionR5" />
+      <sliceName value="diagnosticReportCompositionR5" />
       <short value="Reference to Composition in R5" />
       <definition value="Extensions for converting between R4 and R5 to refer to Composition" />
       <min value="1" />
@@ -69,11 +69,11 @@
         <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
       </type>
     </element>
-    <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5.url">
+    <element id="DiagnosticReport.extension:diagnosticReportCompositionR5.url">
       <path value="DiagnosticReport.extension.url" />
       <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
     </element>
-    <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5.value[x]">
+    <element id="DiagnosticReport.extension:diagnosticReportCompositionR5.value[x]">
       <path value="DiagnosticReport.extension.value[x]" />
       <type>
         <code value="Reference" />

--- a/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
+++ b/Resources/lu-LaboratoryTestResult-DiagnosticReport.xml
@@ -55,18 +55,29 @@
         </discriminator>
         <rules value="open" />
       </slicing>
-      <min value="0" />
+      <min value="1" />
     </element>
     <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5">
       <path value="DiagnosticReport.extension" />
       <sliceName value="DiagnosticReportCompositionR5" />
       <short value="Reference to Composition in R5" />
       <definition value="Extensions for converting between R4 and R5 to refer to Composition" />
-      <min value="0" />
+      <min value="1" />
       <max value="1" />
       <type>
         <code value="Extension" />
         <profile value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
+      </type>
+    </element>
+    <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5.url">
+      <path value="DiagnosticReport.extension.url" />
+      <fixedUri value="http://hl7.org/fhir/5.0/StructureDefinition/extension-DiagnosticReport.composition" />
+    </element>
+    <element id="DiagnosticReport.extension:DiagnosticReportCompositionR5.value[x]">
+      <path value="DiagnosticReport.extension.value[x]" />
+      <type>
+        <code value="Reference" />
+        <targetProfile value="http://nictiz.nl/fhir/StructureDefinition/lu-Composition" />
       </type>
     </element>
     <element id="DiagnosticReport.identifier">
@@ -86,7 +97,7 @@
     <element id="DiagnosticReport.basedOn">
       <path value="DiagnosticReport.basedOn" />
       <short value="Order details" />
-      <definition value="Ordering provider and order details as part of the order request.&#xD;&#xA;&#xD;&#xA;At the moment of creating this profile, the profile on ServiceRequest is not yet created. Therefore, the sending systems are not yet expected to send a ServiceRequest and receiving systems have to be aware that the definition of ServiceRequest is not yet final and may be different from what they currently receive." />
+      <definition value="Ordering provider and order details as part of the order request.&#xD;&#xA;&#xD;&#xA;At the moment of creating this profile, the lu-profile on ServiceRequest is not yet created. Therefore, the sending systems are not yet expected to send a ServiceRequest. Receiving systems have to be aware that the definition of ServiceRequest is not yet final and may be different from what they currently receive." />
       <alias value="Aanvraaggegevens" />
       <type>
         <code value="Reference" />
@@ -110,10 +121,6 @@
         <map value="lu-concept-v2-4287" />
         <comment value="ResultStatus" />
       </mapping>
-    </element>
-    <element id="DiagnosticReport.category">
-      <path value="DiagnosticReport.category" />
-      <min value="1" />
     </element>
     <element id="DiagnosticReport.code">
       <path value="DiagnosticReport.code" />


### PR DESCRIPTION
The lab profiles Composition and DiagnosticReport have been improved to align with [the European FHIR specs for laboratory exchange](https://build.fhir.org/ig/hl7-eu/laboratory/index.html) as much as possible while still complying to [the Nictiz Lab dataset](https://decor.nictiz.nl/ad/#/lu-/datasets/dataset/2.16.840.1.113883.2.4.3.11.60.25.1.2/2021-02-22T00:00:00) as well as [the Nictiz profiling guidelines.](https://informatiestandaarden.nictiz.nl/wiki/FHIR:V1.0_FHIR_Profiling_Guidelines_R4)

The lu-Composition and lu-DiagnosticReport have been created in the following order:

1. Based on the content of the Nictiz dataset, the profiles have been enriched with mappings. If applicable in the dataset, some FHIR elements have been constrained.
2. Then the Nictiz profiles were compared to the European approach laboratory exchange and have been consulted to align as much as possible.

In general the rule applies:
The Nictiz FHIR specification for laboratory exchange, has to align with the European specification for laboratory exchange, unless there is a specific Dutch solution necessary. In that case this points can be raised at the European workgroup for discussion.